### PR TITLE
Put 'enabled'/'disabled' first in long Dutch notification message

### DIFF
--- a/locale/nl/gnome-shell-extension-espresso.po
+++ b/locale/nl/gnome-shell-extension-espresso.po
@@ -20,24 +20,22 @@ msgstr ""
 #: espresso@coadmunkee.github.com/extension.js:557
 msgid "Auto suspend and screensaver disabled. Night Light paused."
 msgstr ""
-"Automatisch in slaapstand zetten, schermbeveiliging en nachtlicht zijn "
-"uitgeschakeld."
+"Uitgeschakeld: Automatisch in slaapstand zetten, schermbeveiliging en nachtlicht."
 
 #: espresso@coadmunkee.github.com/extension.js:559
 msgid "Auto suspend and screensaver disabled"
 msgstr ""
-"Automatisch in slaapstand zetten en schermbeveiliging zijn uitgeschakeld"
+"Uitgeschakeld: Automatisch in slaapstand zetten en schermbeveiliging"
 
 #: espresso@coadmunkee.github.com/extension.js:564
 msgid "Auto suspend and screensaver enabled. Night Light resumed."
 msgstr ""
-"Automatisch in slaapstand zetten, schermbeveiliging en nachtlicht zijn "
-"ingeschakeld."
+"Ingeschakeld: Automatisch in slaapstand zetten, schermbeveiliging en nachtlicht"
 
 #: espresso@coadmunkee.github.com/extension.js:566
 msgid "Auto suspend and screensaver enabled"
 msgstr ""
-"Automatisch in slaapstand zetten en schermbeveiliging zijn ingeschakeld"
+"Ingeschakeld: Automatisch in slaapstand zetten en schermbeveiliging"
 
 #: espresso@coadmunkee.github.com/extension.js:570
 msgid "Turning off \"espresso enabled when docked\""


### PR DESCRIPTION
Only the "Automatisch in slaapstand zetten, schermbeveiligi..." is visible in the notification; both enabling and disabling Espresso would display the same message, so it's not clear from that message what the state has become.

![Schermafdruk van 2022-10-15 09-56-43](https://user-images.githubusercontent.com/869756/195976471-f90441ea-7cd5-4d5b-80eb-7351b1fc233d.png)
