### PR TITLE
Gnome 44 compatibility

### DIFF
--- a/espresso@coadmunkee.github.com/extension.js
+++ b/espresso@coadmunkee.github.com/extension.js
@@ -140,7 +140,11 @@ class Espresso extends PanelMenu.Button {
             this._display = this._screen;
         }
 
-        this._monitor_manager = Meta.MonitorManager.get();
+        if (Meta.MonitorManager.get) {
+            this._monitor_manager = Meta.MonitorManager.get();
+        } else {
+            this._monitor_manager = global.backend.get_monitor_manager();
+        }
 
         this._icon = new St.Icon({
             style_class: 'system-status-icon'

--- a/espresso@coadmunkee.github.com/metadata.json
+++ b/espresso@coadmunkee.github.com/metadata.json
@@ -8,7 +8,8 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/coadmunkee/gnome-shell-extension-espresso",
   "uuid": "espresso@coadmunkee.github.com",


### PR DESCRIPTION
Meta.MonitorManager was dropped in Gnome 44. 

Adapted from https://github.com/ddterm/gnome-shell-extension-ddterm/commit/4c66de2