### PR TITLE
GNOME 47 compatibility

### DIFF
--- a/espresso@coadmunkee.github.com/metadata.json
+++ b/espresso@coadmunkee.github.com/metadata.json
@@ -5,7 +5,7 @@
   "name": "Espresso",
   "settings-schema": "org.gnome.shell.extensions.espresso",
   "shell-version": [
-    "46"
+    "46", "47"
   ],
   "url": "https://github.com/coadmunkee/gnome-shell-extension-espresso",
   "uuid": "espresso@coadmunkee.github.com",


### PR DESCRIPTION
GNOME 47 is scheduled for release on Wednesday.

I did a very simple smoketest with this change on Debian with gnome-shell 47.rc

See also https://gjs.guide/extensions/upgrading/gnome-shell-47.html